### PR TITLE
Create initial AST objects to define API

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -24,6 +24,6 @@ WORKDIR /go/src/github.com/tomnz/glowpher/cmd/glowpher
 RUN go get -u github.com/golang/dep/...
 RUN dep ensure
 
-# Build and run glowpher
+# Build and run Glowpher
 RUN go build -tags=rpiws281x
 CMD ./glowpher

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# glowpher
+# Glowpher
 
 Fully-featured Raspberry Pi WS281x driver, designed to be deployed as a [resin.io](https://resin.io/) image.
 

--- a/ast/common.go
+++ b/ast/common.go
@@ -1,0 +1,8 @@
+package ast
+
+// Param declares the value or variable for a given parameter.
+type Param struct {
+	Value    interface{}      `json:"value"`
+	Variable string           `json:"variable"`
+	Params   map[string]Param `json:"params"`
+}

--- a/ast/playlist.go
+++ b/ast/playlist.go
@@ -1,0 +1,13 @@
+package ast
+
+// Playlist declares a set of scenes that can be shown together.
+type Playlist struct {
+	Scenes          []PlaylistScene `json:"scenes"`
+	DefaultDuration string          `json:"defaultDuration"`
+}
+
+// PlaylistScene declares a scene in a playlist, along with associated metadata.
+type PlaylistScene struct {
+	Scene    Scene  `json:"scene"`
+	Duration string `json:"duration"`
+}

--- a/ast/scene.go
+++ b/ast/scene.go
@@ -1,0 +1,13 @@
+package ast
+
+// Scene declares an overall animated configuration.
+type Scene struct {
+	Name   string
+	Effect []Effect `json:"effects"`
+}
+
+// Effect declares the type and parameters of a given effect.
+type Effect struct {
+	Type   string           `json:"effect"`
+	Params map[string]Param `json:"params"`
+}

--- a/ast/variable.go
+++ b/ast/variable.go
@@ -1,0 +1,8 @@
+package ast
+
+// Variable declares an available variable, along with its base parameters.
+type Variable struct {
+	Name   string           `json:"name"`
+	Type   string           `json:"variable"`
+	Params map[string]Param `json:"params"`
+}

--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 	"goji.io/pat"
 )
 
+// NewHandler instantiates a new handler for serving the Glowpher frontend and API.
 func NewHandler() http.Handler {
 	mux := goji.NewMux()
 	mux.HandleFunc(pat.New("/"), func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The idea is that we'll load/save the application's configurations to/from JSON (and transmit the same structures over the wire via the API). We can define this API as a set of simple Go structs with JSON names. Note that this expresses nothing in terms of type safety, nor does it provide any functionality. There will be a "compilation" step to expand this AST into actual executable code.

Also `s/glowpher/Glowpher/` for text representations.